### PR TITLE
Added .npmrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 /build
 /public/build
 .env
+.npmrc
 
 /cypress/screenshots
 /cypress/videos


### PR DESCRIPTION
This was picked up by gitguardian but after some investigation, no vulnerabilities are 
present. I'm adding this to .gitignore such that it won't be susceptible to vulnerabilities 
later. 

.npmrc is a config file for node package manager, this may be used later so for security sake 
it's being .gitignored
